### PR TITLE
feat(auth): migrate account deletion

### DIFF
--- a/.github/workflows/build-apks.yml
+++ b/.github/workflows/build-apks.yml
@@ -61,7 +61,6 @@ jobs:
           BUBBLE_API_URL: ${{ secrets.BUBBLE_API_URL}} # FIXME: remove BUBBLE_API_URL, not used in capture app.
           APPS_FLYER_DEV_KEY: '' # Empty string prevents apps flyer SDK initialization for non-public flavors.
           NUMBERS_PQINA_NPM_KEY: ${{ secrets.NUMBERS_PQINA_NPM_KEY }} # same for public, non-public flavors.
-          PIPEDREAM_DELETE_CAPTURE_ACCOUNT: ${{ secrets.PIPEDREAM_DELETE_CAPTURE_ACCOUNT }}
           GOOGLE_IOS_CLIENT_ID: ${{ secrets.GOOGLE_IOS_CLIENT_ID }}
           GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.4'
+
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/firebase-release.yml
+++ b/.github/workflows/firebase-release.yml
@@ -44,7 +44,6 @@ jobs:
           BUBBLE_API_URL: ${{ secrets.BUBBLE_API_URL }}
           APPS_FLYER_DEV_KEY: ${{ secrets.APPS_FLYER_DEV_KEY }}
           NUMBERS_PQINA_NPM_KEY: ${{ secrets.NUMBERS_PQINA_NPM_KEY }}
-          PIPEDREAM_DELETE_CAPTURE_ACCOUNT: ${{ secrets.PIPEDREAM_DELETE_CAPTURE_ACCOUNT }}
           GOOGLE_IOS_CLIENT_ID: ${{ secrets.GOOGLE_IOS_CLIENT_ID }}
           GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
         run: |
@@ -114,7 +113,6 @@ jobs:
           BUBBLE_API_URL: ${{ secrets.BUBBLE_API_URL }}
           APPS_FLYER_DEV_KEY: ${{ secrets.APPS_FLYER_DEV_KEY }}
           NUMBERS_PQINA_NPM_KEY: ${{ secrets.NUMBERS_PQINA_NPM_KEY }}
-          PIPEDREAM_DELETE_CAPTURE_ACCOUNT: ${{ secrets.PIPEDREAM_DELETE_CAPTURE_ACCOUNT }}
           GOOGLE_IOS_CLIENT_ID: ${{ secrets.GOOGLE_IOS_CLIENT_ID }}
           GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
         run: |

--- a/.github/workflows/firebase-release.yml
+++ b/.github/workflows/firebase-release.yml
@@ -91,6 +91,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.4'
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20.11.1'

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -176,6 +176,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.4'
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20.11.1'
@@ -263,6 +268,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.4'
 
       - name: Download IPA
         uses: actions/download-artifact@v4

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -30,7 +30,6 @@ jobs:
           BUBBLE_API_URL: ${{ secrets.BUBBLE_API_URL }}
           APPS_FLYER_DEV_KEY: ${{ secrets.APPS_FLYER_DEV_KEY }}
           NUMBERS_PQINA_NPM_KEY: ${{ secrets.NUMBERS_PQINA_NPM_KEY }}
-          PIPEDREAM_DELETE_CAPTURE_ACCOUNT: ${{ secrets.PIPEDREAM_DELETE_CAPTURE_ACCOUNT }}
           GOOGLE_IOS_CLIENT_ID: ${{ secrets.GOOGLE_IOS_CLIENT_ID }}
           GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
         run: |
@@ -110,7 +109,6 @@ jobs:
           BUBBLE_API_URL: ${{ secrets.BUBBLE_API_URL }}
           APPS_FLYER_DEV_KEY: ${{ secrets.APPS_FLYER_DEV_KEY }}
           NUMBERS_PQINA_NPM_KEY: ${{ secrets.NUMBERS_PQINA_NPM_KEY }}
-          PIPEDREAM_DELETE_CAPTURE_ACCOUNT: ${{ secrets.PIPEDREAM_DELETE_CAPTURE_ACCOUNT }}
           GOOGLE_IOS_CLIENT_ID: ${{ secrets.GOOGLE_IOS_CLIENT_ID }}
           GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
         run: |
@@ -200,7 +198,6 @@ jobs:
           BUBBLE_API_URL: ${{ secrets.BUBBLE_API_URL }}
           APPS_FLYER_DEV_KEY: ${{ secrets.APPS_FLYER_DEV_KEY }}
           NUMBERS_PQINA_NPM_KEY: ${{ secrets.NUMBERS_PQINA_NPM_KEY }}
-          PIPEDREAM_DELETE_CAPTURE_ACCOUNT: ${{ secrets.PIPEDREAM_DELETE_CAPTURE_ACCOUNT }}
           GOOGLE_IOS_CLIENT_ID: ${{ secrets.GOOGLE_IOS_CLIENT_ID }}
           GOOGLE_WEB_CLIENT_ID: ${{ secrets.GOOGLE_WEB_CLIENT_ID }}
         run: |

--- a/set-secret.js
+++ b/set-secret.js
@@ -13,7 +13,6 @@ export const BUBBLE_API_URL = '${process.env.BUBBLE_API_URL}';
 export const APPS_FLYER_DEV_KEY = '${process.env.APPS_FLYER_DEV_KEY}'
 export const GOOGLE_IOS_CLIENT_ID = '${process.env.GOOGLE_IOS_CLIENT_ID}'
 export const GOOGLE_WEB_CLIENT_ID = '${process.env.GOOGLE_WEB_CLIENT_ID}'
-export const PIPEDREAM_DELETE_CAPTURE_ACCOUNT = '${process.env.PIPEDREAM_DELETE_CAPTURE_ACCOUNT}'
 `;
 fs.writeFile(targetPath, envConfigFile, err => {
   if (err) {

--- a/src/app/features/settings/settings.page.ts
+++ b/src/app/features/settings/settings.page.ts
@@ -181,9 +181,7 @@ export class SettingsPage {
   }
 
   async deleteAccount() {
-    const email: string = await this.diaBackendAuthService.getEmail();
-
-    const action$ = this.diaBackendAuthService.deleteAccount$(email).pipe(
+    const action$ = this.diaBackendAuthService.deleteAccount$().pipe(
       // logout
       concatMapTo(defer(() => this.mediaStore.clear())),
       concatMapTo(defer(() => this.database.clear())),

--- a/src/app/shared/dia-backend/auth/dia-backend-auth.service.ts
+++ b/src/app/shared/dia-backend/auth/dia-backend-auth.service.ts
@@ -24,11 +24,7 @@ import { secondSince } from '../../../utils/date';
 import { LanguageService } from '../../language/service/language.service';
 import { PreferenceManager } from '../../preference-manager/preference-manager.service';
 import { PushNotificationService } from '../../push-notification/push-notification.service';
-import {
-  BASE_URL,
-  PIPEDREAM_DELETE_CAPTURE_ACCOUNT,
-  TRUSTED_CLIENT_KEY,
-} from '../secret';
+import { BASE_URL, TRUSTED_CLIENT_KEY } from '../secret';
 
 @Injectable({
   providedIn: 'root',
@@ -315,19 +311,14 @@ export class DiaBackendAuthService {
     );
   }
 
-  deleteAccount$(email: string) {
+  deleteAccount$() {
     return defer(() => this.getAuthHeaders()).pipe(
       concatMap(authHeaders => {
-        const body = { email };
-        return this.httpClient.post<any>(
-          `${PIPEDREAM_DELETE_CAPTURE_ACCOUNT}`,
-          body,
-          {
-            headers: new HttpHeaders()
-              .set('Authorization', `${authHeaders.authorization}`)
-              .set('Content-Type', 'application/json'),
-          }
-        );
+        return this.httpClient.delete<any>(`${BASE_URL}/auth/users/me/`, {
+          headers: new HttpHeaders()
+            .set('Authorization', `${authHeaders.authorization}`)
+            .set('Content-Type', 'application/json'),
+        });
       })
     );
   }


### PR DESCRIPTION
Ref numbersprotocol/pipedream#11

- Replace Pipedream webhook with backend DELETE /auth/users/me/ endpoint
- Remove unused email parameter from deleteAccount$() method